### PR TITLE
ci: canonical docker-build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,38 +1,19 @@
 name: Docker
-
 on:
-  push:
-    branches: [main]
-    tags: ['v*']
   workflow_dispatch:
-
+  push:
+    branches: [main, dev, test]
+    tags: ['v*']
+permissions:
+  contents: read
+  packages: write
 jobs:
-  build-push:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/metadata-action@v5
-        id: meta
-        with:
-          images: ghcr.io/hanzoai/hanzo-login
-          tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,prefix=,suffix=,format=short
-            type=semver,pattern={{version}}
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          platforms: linux/amd64
-          tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+  docker:
+    uses: hanzoai/.github/.github/workflows/docker-build.yml@main
+    with:
+      image: ghcr.io/hanzoai/id
+      pre-build-command: |
+        corepack enable
+        pnpm install --frozen-lockfile
+        pnpm build
+    secrets: inherit

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -1,0 +1,7 @@
+name: Workflow Sanity
+on:
+  pull_request:
+    paths: ['.github/workflows/**']
+jobs:
+  sanity:
+    uses: hanzoai/.github/.github/workflows/workflow-sanity.yml@main


### PR DESCRIPTION
Migrates to shared `hanzoai/.github/.github/workflows/docker-build.yml@main`. Native multi-arch via Hanzo ARC. No GitHub runners, no QEMU. Adds workflow-sanity.

## Test plan
- [ ] CI green = canonical on ARC